### PR TITLE
use favicon instead of full logo in collapsed sidebar

### DIFF
--- a/src/assets/styles/spec/components/sidebar.scss
+++ b/src/assets/styles/spec/components/sidebar.scss
@@ -69,6 +69,13 @@
       }
     }
 
+    &:not(:hover) .sidebar-logo .logo img {
+      width: 32px;
+      height: 32px;
+      margin: 0 20px;
+      content: url("/favicon.ico");
+    }
+
     &:hover {
       width: $offscreen-size;
 


### PR DESCRIPTION
closes #8