### PR TITLE
Form: Example hashtag in lower case

### DIFF
--- a/src/app/dashboard/query/query.component.html
+++ b/src/app/dashboard/query/query.component.html
@@ -12,7 +12,7 @@
               <input type="text" class="form-control" id="hastags" name="hastags" 
                   [(ngModel)]="hashtags"
                   placeholder="Enter the Hashtags separated by commas">
-              <small id="hastagsHelp" class="text-muted"> Hashtags used in Changesets comments eg: MissingMaps</small>
+              <small id="hastagsHelp" class="text-muted"> Hashtags used in Changesets comments eg: missingmaps</small>
             </div>
           </div>
           <div class="row">


### PR DESCRIPTION
I tried running the app and it looks like it requires the hashtags to be lower case, so this updates the example.